### PR TITLE
feat: better cli error handling

### DIFF
--- a/pkg/auth/event.go
+++ b/pkg/auth/event.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -65,7 +66,7 @@ func handleAuthResponse(resp *http.Response) {
 	err = json.Unmarshal(body, &eventToken)
 	common.CliExit(err)
 	if &eventToken.IdToken == nil || len(eventToken.IdToken) == 0 {
-		common.CliExit(fmt.Sprintf("Cannot get ID token from auth response %s", body))
+		common.CliExit(errors.New(fmt.Sprintf("Cannot get ID token from auth response %s", body)))
 	}
 	token = &eventToken
 }

--- a/pkg/auth/user.go
+++ b/pkg/auth/user.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/int128/oauth2cli"
@@ -70,7 +71,7 @@ func (authenticator *Authenticator) accessToken() *string {
 		tokens, err := authenticator.tokenSource.Token()
 		if err != nil {
 			authenticator.revoke()
-			common.CliExit(fmt.Sprintf("Your session has expired. Please re-login using: `%s auth login`", common.RootCommandName))
+			common.CliExit(errors.New(fmt.Sprintf("Your session has expired. Please re-login using: `%s auth login`", common.RootCommandName)))
 		}
 		if authenticator.storedToken.AccessToken != tokens.AccessToken {
 			authenticator.populateValues(oauthTokenToStoredToken(*tokens))
@@ -110,7 +111,7 @@ func (authenticator *Authenticator) login() {
 	eg.Go(authenticator.handleLogin(ctx, cfg))
 
 	if err := eg.Wait(); err != nil {
-		common.CliExit(fmt.Sprintf("Login failed, please check the logs for details at %v", common.LogFileName()))
+		common.CliExit(errors.New(fmt.Sprintf("Login failed, please check the logs for details at %v", common.LogFileName())))
 	}
 }
 
@@ -148,7 +149,7 @@ func startBrowserLoginFlow(ready chan string, ctx context.Context) func() error 
 				err := browser.OpenURL(localCallbackServerUrl)
 
 				if err != nil {
-					browserOpenError := fmt.Sprintf("Unable to open browser for authentication: %s", err)
+					browserOpenError := errors.New(fmt.Sprintf("Unable to open browser for authentication: %s", err))
 					log.Error(browserOpenError)
 					common.CliExit(browserOpenError)
 				}
@@ -188,7 +189,7 @@ func getEmailFromClaims(t oauth2.Token) string {
 func authorizationCodeFlowUrl(url string) string {
 	locationResponse, err := http.Get(url)
 	if err != nil {
-		common.CliExit("Could not retrieve authorization code flow URL. Please retry or contact STRM Privacy support if the problem persists.")
+		common.CliExit(errors.New("Could not retrieve authorization code flow URL. Please retry or contact STRM Privacy support if the problem persists."))
 	}
 
 	return locationResponse.Request.URL.String()
@@ -217,7 +218,7 @@ func findFreePort() int {
 		}
 
 		if !foundOpenPort {
-			common.CliExit("Unable to find free port in range 10000 <= port <= 10009. Please check your running applications and make sure that a port in this range is free.")
+			common.CliExit(errors.New("Unable to find free port in range 10000 <= port <= 10009. Please check your running applications and make sure that a port in this range is free."))
 		}
 
 		return port

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -2,14 +2,18 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"gopkg.in/natefinch/lumberjack.v2"
+	"os"
 	"runtime"
 	"strings"
 )
@@ -59,16 +63,28 @@ func LogFileName() string {
 	return ConfigPath + "/" + RootCommandName + ".log"
 }
 
-func CliExit(msg interface{}) {
-	if msg != nil {
+func CliExit(err error) {
+	if err != nil {
 		_, file, line, _ := runtime.Caller(1)
-		log.WithFields(log.Fields{"file": file, "line": line}).Error(msg)
-		cobra.CheckErr(msg)
+		log.WithFields(log.Fields{"file": file, "line": line}).Error(err)
+
+		st, ok := status.FromError(err)
+
+		if ok {
+			switch (*st).Code() {
+			case codes.FailedPrecondition:
+				fmt.Fprintln(os.Stderr, "A precondition failed for this command:", (*st).Message())
+			}
+		} else {
+			fmt.Fprintln(os.Stderr, err)
+		}
+
+		os.Exit(1)
 	}
 }
 
 func MissingIdTokenError() {
-	CliExit(fmt.Sprintf("No login information found. Use: `%v auth login` first.", RootCommandName))
+	CliExit(errors.New(fmt.Sprintf("No login information found. Use: `%v auth login` first.", RootCommandName)))
 }
 
 func MissingBillingIdCompletionError(commandPath string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"io/ioutil"
@@ -61,7 +62,7 @@ func billingIdInfo() {
 	b, err := auth.GetBillingId()
 	if err != nil {
 		if fileError, ok := err.(*fs.PathError); ok {
-			common.CliExit(fmt.Sprintf("Can't %s %s", fileError.Op, fileError.Path))
+			common.CliExit(errors.New(fmt.Sprintf("Can't %s %s", fileError.Op, fileError.Path)))
 		}
 	}
 	common.CliExit(err)

--- a/pkg/context/printers.go
+++ b/pkg/context/printers.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/list"
 	"github.com/spf13/cobra"
@@ -30,7 +31,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 			allowedValues = common.ConfigOutputFormatFlagAllowedValuesText
 		}
 
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported for '%v'. Allowed values: %v", command.CommandPath(), outputFormat, allowedValues))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported for '%v'. Allowed values: %v", command.CommandPath(), outputFormat, allowedValues)))
 	}
 
 	return p

--- a/pkg/entity/batch_exporter/batch_exporter.go
+++ b/pkg/entity/batch_exporter/batch_exporter.go
@@ -2,6 +2,7 @@ package batch_exporter
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/golang/protobuf/ptypes/duration"
@@ -60,7 +61,7 @@ func create(streamName *string, cmd *cobra.Command) {
 		sinkName = sinkNames[0]
 	}
 	if len(sinkName) == 0 {
-		common.CliExit("You must provide a sink name when creating a batch exporter")
+		common.CliExit(errors.New("You must provide a sink name when creating a batch exporter"))
 	}
 	// this exporterName might be empty, in which case the API will set it to
 	// the appropriate default

--- a/pkg/entity/batch_exporter/printers.go
+++ b/pkg/entity/batch_exporter/printers.go
@@ -1,6 +1,7 @@
 package batch_exporter
 
 import (
+	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -18,7 +19,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 	p := availablePrinters()[outputFormat+command.Parent().Name()]
 
 	if p == nil {
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText)))
 	}
 
 	return p

--- a/pkg/entity/batch_job/printers.go
+++ b/pkg/entity/batch_job/printers.go
@@ -1,6 +1,7 @@
 package batch_job
 
 import (
+	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -19,7 +20,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 	p := availablePrinters()[outputFormat+command.Parent().Name()]
 
 	if p == nil {
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText)))
 	}
 
 	return p

--- a/pkg/entity/event_contract/event_contract.go
+++ b/pkg/entity/event_contract/event_contract.go
@@ -3,6 +3,7 @@ package event_contract
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
 	entities "github.com/strmprivacy/api-definitions-go/v2/api/entities/v1"
@@ -32,7 +33,7 @@ func ref(refString *string) *entities.EventContractRef {
 	parts := strings.Split(*refString, "/")
 
 	if len(parts) != 3 {
-		common.CliExit("Event Contract reference should consist of three parts: <handle>/<name>/<version>")
+		common.CliExit(errors.New("Event Contract reference should consist of three parts: <handle>/<name>/<version>"))
 	}
 
 	return &entities.EventContractRef{

--- a/pkg/entity/event_contract/printers.go
+++ b/pkg/entity/event_contract/printers.go
@@ -1,6 +1,7 @@
 package event_contract
 
 import (
+	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -19,7 +20,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 	p := availablePrinters()[outputFormat+command.Parent().Name()]
 
 	if p == nil {
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText)))
 	}
 
 	return p

--- a/pkg/entity/installation/printers.go
+++ b/pkg/entity/installation/printers.go
@@ -1,6 +1,7 @@
 package installation
 
 import (
+	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -17,7 +18,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 	p := availablePrinters()[outputFormat+command.Parent().Name()]
 
 	if p == nil {
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText)))
 	}
 
 	return p

--- a/pkg/entity/kafka_cluster/printers.go
+++ b/pkg/entity/kafka_cluster/printers.go
@@ -1,6 +1,7 @@
 package kafka_cluster
 
 import (
+	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -18,7 +19,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 	p := availablePrinters()[outputFormat+command.Parent().Name()]
 
 	if p == nil {
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText)))
 	}
 
 	return p

--- a/pkg/entity/kafka_exporter/printers.go
+++ b/pkg/entity/kafka_exporter/printers.go
@@ -1,6 +1,7 @@
 package kafka_exporter
 
 import (
+	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -19,7 +20,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 	p := availablePrinters()[outputFormat+command.Parent().Name()]
 
 	if p == nil {
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText)))
 	}
 
 	return p

--- a/pkg/entity/kafka_user/printers.go
+++ b/pkg/entity/kafka_user/printers.go
@@ -1,6 +1,7 @@
 package kafka_user
 
 import (
+	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -18,7 +19,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 	p := availablePrinters()[outputFormat+command.Parent().Name()]
 
 	if p == nil {
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText)))
 	}
 
 	return p

--- a/pkg/entity/key_stream/printers.go
+++ b/pkg/entity/key_stream/printers.go
@@ -1,6 +1,7 @@
 package key_stream
 
 import (
+	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -18,7 +19,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 	p := availablePrinters()[outputFormat+command.Parent().Name()]
 
 	if p == nil {
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText)))
 	}
 
 	return p

--- a/pkg/entity/schema/printers.go
+++ b/pkg/entity/schema/printers.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -18,7 +19,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 	p := availablePrinters()[outputFormat+command.Parent().Name()]
 
 	if p == nil {
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText)))
 	}
 
 	return p

--- a/pkg/entity/schema/schema.go
+++ b/pkg/entity/schema/schema.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -33,7 +34,7 @@ func Ref(refString *string) *entities.SchemaRef {
 	parts := strings.Split(*refString, "/")
 
 	if len(parts) != 3 {
-		common.CliExit("Schema reference should consist of three parts: <handle>/<name>/<version>")
+		common.CliExit(errors.New("Schema reference should consist of three parts: <handle>/<name>/<version>"))
 	}
 
 	return &entities.SchemaRef{
@@ -133,8 +134,8 @@ func create(cmd *cobra.Command, args *string) {
 	typeString := util.GetStringAndErr(flags, schemaTypeFlag)
 	schemaType, ok := entities.SchemaType_value[typeString]
 	if !ok {
-		common.CliExit(fmt.Sprintf("Can't convert %s to a known consent sink type, types are %v",
-			typeString, entities.SchemaType_value))
+		common.CliExit(errors.New(fmt.Sprintf("Can't convert %s to a known consent sink type, types are %v",
+			typeString, entities.SchemaType_value)))
 	}
 	definitionFilename := util.GetStringAndErr(flags, definitionFlag)
 	definition, err := ioutil.ReadFile(definitionFilename)

--- a/pkg/entity/schema_code/schema_code.go
+++ b/pkg/entity/schema_code/schema_code.go
@@ -2,6 +2,7 @@ package schema_code
 
 import (
 	"context"
+	"errors"
 	"github.com/spf13/cobra"
 	"github.com/strmprivacy/api-definitions-go/v2/api/schemas/v1"
 	"google.golang.org/grpc"
@@ -49,7 +50,7 @@ func GetSchemaCode(cmd *cobra.Command, name *string) string {
 	if !overwrite {
 		_, err = os.Stat(outputFile)
 		if !os.IsNotExist(err) {
-			common.CliExit("Not overwriting " + outputFile)
+			common.CliExit(errors.New("Not overwriting " + outputFile))
 		}
 	}
 	saveFile(schemaCode, outputFile)

--- a/pkg/entity/sink/printers.go
+++ b/pkg/entity/sink/printers.go
@@ -1,6 +1,7 @@
 package sink
 
 import (
+	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -18,7 +19,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 	p := availablePrinters()[outputFormat+command.Parent().Name()]
 
 	if p == nil {
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText)))
 	}
 
 	return p

--- a/pkg/entity/sink/sink.go
+++ b/pkg/entity/sink/sink.go
@@ -2,6 +2,7 @@ package sink
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -80,8 +81,8 @@ func parseSyncType(flags *pflag.FlagSet) entities.SinkType {
 	}
 	sinkType, ok := entities.SinkType_value[typeString]
 	if !ok {
-		common.CliExit(fmt.Sprintf("Can't convert %s to a known consent sink type, types are %v",
-			typeString, entities.SinkType_value))
+		common.CliExit(errors.New(fmt.Sprintf("Can't convert %s to a known consent sink type, types are %v",
+			typeString, entities.SinkType_value)))
 	}
 	return entities.SinkType(sinkType)
 }

--- a/pkg/entity/stream/printers.go
+++ b/pkg/entity/stream/printers.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"errors"
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -19,7 +20,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 	p := availablePrinters()[outputFormat+command.Parent().Name()]
 
 	if p == nil {
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported. Allowed values: %v", outputFormat, common.OutputFormatFlagAllowedValuesText)))
 	}
 
 	return p

--- a/pkg/entity/stream/stream.go
+++ b/pkg/entity/stream/stream.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -43,7 +44,7 @@ func SetupClient(clientConnection *grpc.ClientConn, ctx context.Context) {
 
 func Get(streamName *string, recursive bool) *streams.GetStreamResponse {
 	if len(strings.TrimSpace(auth.Auth.BillingId())) == 0 {
-		common.CliExit(fmt.Sprintf("No login information found. Use: `%v auth login` first.", common.RootCommandName))
+		common.CliExit(errors.New(fmt.Sprintf("No login information found. Use: `%v auth login` first.", common.RootCommandName)))
 	}
 
 	req := &streams.GetStreamRequest{
@@ -90,13 +91,13 @@ func create(args []string, cmd *cobra.Command) {
 	if len(linkedStream) != 0 {
 		stream.ConsentLevels, err = flags.GetInt32Slice(consentLevelsFlag)
 		if len(stream.ConsentLevels) == 0 {
-			common.CliExit("You need consent levels when creating a derived stream")
+			common.CliExit(errors.New("You need consent levels when creating a derived stream"))
 		}
 		stream.ConsentLevelType, err = parseConsentLevelType(flags)
 		stream.LinkedStream = linkedStream
 	} else {
 		if len(stream.Ref.Name) == 0 {
-			common.CliExit("You must provide a name when creating a source stream")
+			common.CliExit(errors.New("You must provide a name when creating a source stream"))
 		}
 	}
 

--- a/pkg/entity/usage/printers.go
+++ b/pkg/entity/usage/printers.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"errors"
 	"fmt"
 	"github.com/bykof/gostradamus"
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -20,7 +21,7 @@ func configurePrinter(command *cobra.Command) util.Printer {
 	p := availablePrinters()[outputFormat]
 
 	if p == nil {
-		common.CliExit(fmt.Sprintf("Output format '%v' is not supported for usage. Allowed values: %v", outputFormat, common.UsageOutputFormatFlagAllowedValuesText))
+		common.CliExit(errors.New(fmt.Sprintf("Output format '%v' is not supported for usage. Allowed values: %v", outputFormat, common.UsageOutputFormatFlagAllowedValuesText)))
 	}
 
 	return p

--- a/pkg/entity/usage/usage.go
+++ b/pkg/entity/usage/usage.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/bykof/gostradamus"
 	"github.com/golang/protobuf/ptypes/duration"
@@ -82,7 +83,7 @@ func interpretInterval(by string) int64 {
 		pat := regexp.MustCompilePOSIX(`^([0-9]+)([mshd])$`)
 		r := pat.FindAllStringSubmatch(strings.ToLower(by), -1)
 		if r == nil {
-			common.CliExit(fmt.Sprintf("%v not understood as interval format", by))
+			common.CliExit(errors.New(fmt.Sprintf("%v not understood as interval format", by)))
 		}
 		lookup := map[string]int64{
 			"m": 60,
@@ -92,7 +93,7 @@ func interpretInterval(by string) int64 {
 		}
 		v, ok := lookup[r[0][2]]
 		if !ok {
-			common.CliExit("Don't understand unit " + r[0][2])
+			common.CliExit(errors.New("Don't understand unit " + r[0][2]))
 		}
 		interval, err = strconv.ParseInt(r[0][1], 10, 64)
 		common.CliExit(err)

--- a/pkg/kafkaconsumer/consumer.go
+++ b/pkg/kafkaconsumer/consumer.go
@@ -2,6 +2,7 @@ package kafkaconsumer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/Shopify/sarama"
 	"github.com/spf13/cobra"
@@ -36,7 +37,7 @@ func Run(cmd *cobra.Command, kafkaExporterName *string) {
 	topic := kafkaExporter.Target.Topic
 	groupId := util.GetStringAndErr(flags, GroupIdFlag)
 	if len(groupId) == 0 {
-		common.CliExit(fmt.Sprintf("Please set a Kafka Consumer group id with --%v", GroupIdFlag))
+		common.CliExit(errors.New(fmt.Sprintf("Please set a Kafka Consumer group id with --%v", GroupIdFlag)))
 	}
 
 	//sarama.Logger = log.New(os.Stdout, "[sarama] ", log.LstdFlags)
@@ -57,7 +58,7 @@ func Run(cmd *cobra.Command, kafkaExporterName *string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	client, err := sarama.NewConsumerGroup(strings.Split(bootstrapBrokers, ","), groupId, config)
 	if err != nil {
-		common.CliExit(fmt.Sprintf("Error creating consumer group client: %v", err))
+		common.CliExit(errors.New(fmt.Sprintf("Error creating consumer group client: %v", err)))
 	}
 
 	wg := &sync.WaitGroup{}
@@ -69,7 +70,7 @@ func Run(cmd *cobra.Command, kafkaExporterName *string) {
 			// server-side rebalance happens, the consumer session will need to be
 			// recreated to get the new claims
 			if err := client.Consume(ctx, []string{topic}, &consumer); err != nil {
-				common.CliExit(fmt.Sprintf("Error from consumer: %v", err))
+				common.CliExit(errors.New(fmt.Sprintf("Error from consumer: %v", err)))
 			}
 			// check if context was cancelled, signaling that the consumer should stop
 			if ctx.Err() != nil {
@@ -92,7 +93,7 @@ func Run(cmd *cobra.Command, kafkaExporterName *string) {
 	cancel()
 	wg.Wait()
 	if err = client.Close(); err != nil {
-		common.CliExit(fmt.Sprintf("Error closing client: %v", err))
+		common.CliExit(errors.New(fmt.Sprintf("Error closing client: %v", err)))
 	}
 
 }

--- a/pkg/simulator/random_events/randomsim.go
+++ b/pkg/simulator/random_events/randomsim.go
@@ -1,6 +1,7 @@
 package random_events
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -26,7 +27,7 @@ func run(cmd *cobra.Command, streamName *string) {
 		clientId := util.GetStringAndErr(flags, common.ClientIdFlag)
 		clientSecret := util.GetStringAndErr(flags, common.ClientSecretFlag)
 		if len(clientId) == 0 || len(clientSecret) == 0 {
-			common.CliExit(fmt.Sprintf("There are no credentials stored for stream '%s'", *streamName))
+			common.CliExit(errors.New(fmt.Sprintf("There are no credentials stored for stream '%s'", *streamName)))
 		}
 		s.Credentials = append(s.Credentials, &entities.Credentials{
 			ClientSecret: clientSecret, ClientId: clientId,
@@ -34,7 +35,7 @@ func run(cmd *cobra.Command, streamName *string) {
 	}
 	streamInfo := stream.Get(streamName, false)
 	if len(streamInfo.StreamTree.Stream.LinkedStream) != 0 {
-		common.CliExit("You can't run a simulator on a derived stream")
+		common.CliExit(errors.New("You can't run a simulator on a derived stream"))
 	}
 	interval := time.Duration(util.GetIntAndErr(flags, sim.IntervalFlag))
 	sessionRange := util.GetIntAndErr(flags, sim.SessionRangeFlag)
@@ -47,11 +48,11 @@ func run(cmd *cobra.Command, streamName *string) {
 	schema := util.GetStringAndErr(flags, sim.SchemaFlag)
 	f := EventGenerators[schema]
 	if f == nil {
-		common.CliExit(fmt.Sprintf("Can't simulate for schema %s", schema))
+		common.CliExit(errors.New(fmt.Sprintf("Can't simulate for schema %s", schema)))
 	}
 
 	if len(consentLevels) == 0 {
-		common.CliExit(fmt.Sprintf("%v is not a valid set of consent levels", consentLevels))
+		common.CliExit(errors.New(fmt.Sprintf("%v is not a valid set of consent levels", consentLevels)))
 	}
 
 	if !quiet {

--- a/pkg/web_socket/web_socket.go
+++ b/pkg/web_socket/web_socket.go
@@ -1,6 +1,7 @@
 package web_socket
 
 import (
+	"errors"
 	"fmt"
 	"github.com/gorilla/websocket"
 	"github.com/spf13/cobra"
@@ -27,8 +28,8 @@ func Run(cmd *cobra.Command, streamName *string) {
 		clientId := util.GetStringAndErr(flags, common.ClientIdFlag)
 		clientSecret := util.GetStringAndErr(flags, common.ClientSecretFlag)
 		if len(clientId) == 0 || len(clientSecret) == 0 {
-			common.CliExit(fmt.Sprintf("There's no saved stream for %s and clientId %s clientSecret %s are missing as options",
-				*streamName, clientId, clientSecret))
+			common.CliExit(errors.New(fmt.Sprintf("There's no saved stream for %s and clientId %s clientSecret %s are missing as options",
+				*streamName, clientId, clientSecret)))
 		}
 		s.Credentials = append(s.Credentials, &entities.Credentials{
 			ClientSecret: clientSecret, ClientId: clientId,


### PR DESCRIPTION
Made the `CliExit` function accept a parameter of type `error`, instead of `interface{}`. This allows for converting the error into a `status.Status`, which allows access to the individual elements of the gRPC response in case of an error.