### PR TITLE
feat: renamed consent to purpose

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -18,11 +18,12 @@ const DefaultConfigFilename = "config"
 const DefaultConfigFileSuffix = ".yaml"
 
 var DefaultConfigFileContents = []byte(`# The following configuration options are reflected in the CLI's flags
-# save: true
+# save: false
 # events-auth-url: https://sts.strmprivacy.io
 # events-api-url: https://events.strmprivacy.io/event
 # api-auth-url: https://accounts.strmprivacy.io
 # api-host: api.strmprivacy.io:443
+# web-socket-url: wss://websocket.strmprivacy.io/ws
 # kafka-bootstrap-hosts: export-bootstrap.kafka.strmprivacy.io:9092
 `)
 

--- a/pkg/entity/data_connector/azure_blob_storage.go
+++ b/pkg/entity/data_connector/azure_blob_storage.go
@@ -11,7 +11,7 @@ const (
 	tenantIdFlag          = "tenant-id"
 	clientIdFlag          = "client-id"
 	clientSecretFlag      = "client-secret"
-	longDocBlobStorage = `Creates a data connector for an Azure Blob Storage container. Authentication is based on
+	longDocBlobStorage    = `Creates a data connector for an Azure Blob Storage container. Authentication is based on
 Client Secret Credentials, i.e. of an Application Principal.
 
 ### Usage`

--- a/pkg/entity/data_connector/gcs_bucket.go
+++ b/pkg/entity/data_connector/gcs_bucket.go
@@ -10,6 +10,7 @@ const (
 
 ### Usage`
 )
+
 func createGcsBucketCmd() *cobra.Command {
 	gcsBucket := &cobra.Command{
 		Use:               "gcs [data-connector-name] [bucket-name]",
@@ -28,8 +29,8 @@ func createGcsBucketCmd() *cobra.Command {
 				Ref: ref(dataConnectorName),
 				Location: &entities.DataConnector_GoogleCloudStorageBucket{
 					GoogleCloudStorageBucket: &entities.GoogleCloudStorageBucketLocation{
-						BucketName:    *bucketName,
-						Credentials:   credentials,
+						BucketName:  *bucketName,
+						Credentials: credentials,
 					},
 				},
 			}

--- a/pkg/entity/data_connector/s3_bucket.go
+++ b/pkg/entity/data_connector/s3_bucket.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	assumeRoleArnFlag = "assume-role-arn"
-	longDocS3 = `Creates a data connector for an AWS S3 bucket. An ARN can be specified in case a role should be assumed.
+	longDocS3         = `Creates a data connector for an AWS S3 bucket. An ARN can be specified in case a role should be assumed.
 
 ### Usage`
 )

--- a/pkg/entity/schema/schema.go
+++ b/pkg/entity/schema/schema.go
@@ -134,7 +134,7 @@ func create(cmd *cobra.Command, args *string) {
 	typeString := util.GetStringAndErr(flags, schemaTypeFlag)
 	schemaType, ok := entities.SchemaType_value[typeString]
 	if !ok {
-		common.CliExit(errors.New(fmt.Sprintf("Can't convert %s to a known consent schema type, types are %v",
+		common.CliExit(errors.New(fmt.Sprintf("Can't convert %s to a known schema type, types are %v",
 			typeString, entities.SchemaType_value)))
 	}
 	definitionFilename := util.GetStringAndErr(flags, definitionFlag)

--- a/pkg/entity/stream/cmd.go
+++ b/pkg/entity/stream/cmd.go
@@ -1,10 +1,11 @@
 package stream
 
 import (
-	"github.com/spf13/cobra"
 	"strmprivacy/strm/pkg/common"
 	"strmprivacy/strm/pkg/entity/event_contract"
 	"strmprivacy/strm/pkg/util"
+
+	"github.com/spf13/cobra"
 )
 
 var longDoc = `A stream is the central resource in STRM Privacy. Clients can connect to a stream to send and to receive events. A
@@ -14,9 +15,9 @@ Events are always sent to an input stream. Sending events to a derived stream is
 encryption of all PII fields, STRM Privacy sends all events to the input stream. Clients consuming from the input stream
 will see all events, but with all PII fields encrypted.
 
-Derived streams can be made on top of a input stream. A derived stream is configured with one or more consent levels and
-it only receives events with matching consent levels (see details about this matching process here). The PII fields with
-matching consent levels are decrypted and sent to the derived stream. Clients connecting to the derived stream will only
+Derived streams can be made on top of a input stream. A derived stream is configured with one or more purpose levels and
+it only receives events with matching purpose levels (see details about this matching process here). The PII fields with
+matching purpose levels are decrypted and sent to the derived stream. Clients connecting to the derived stream will only
 receive the events on this stream.
 
 Every stream has its own set of access tokens. Connecting to an input stream requires different credentials than when

--- a/pkg/entity/stream/printers.go
+++ b/pkg/entity/stream/printers.go
@@ -97,6 +97,7 @@ func printTable(streamTreeArray []*v1.StreamTree) {
 		} else {
 			consentLevelType = ""
 		}
+		consentLevelType = util.ReplaceConsent(consentLevelType)
 
 		rows = append(rows, table.Row{
 			stream.Stream.Ref.Name,
@@ -111,8 +112,8 @@ func printTable(streamTreeArray []*v1.StreamTree) {
 		table.Row{
 			"Stream",
 			"Derived",
-			"Consent Level Type",
-			"Consent Levels",
+			"Purpose Level Type",
+			"Purpose Levels",
 			"Enabled",
 		},
 		rows,

--- a/pkg/simulator/random_events/cmd.go
+++ b/pkg/simulator/random_events/cmd.go
@@ -1,10 +1,11 @@
 package random_events
 
 import (
-	"github.com/spf13/cobra"
 	"strmprivacy/strm/pkg/common"
 	"strmprivacy/strm/pkg/entity/stream"
-	"strmprivacy/strm/pkg/simulator"
+	sim "strmprivacy/strm/pkg/simulator"
+
+	"github.com/spf13/cobra"
 )
 
 var longDoc = `The global ` + "`simulate`" + ` command runs a simulation with random events against a given Source Stream, using the ClickStream
@@ -30,6 +31,6 @@ func RunCmd() (cmd *cobra.Command) {
 	flags.String(common.ClientIdFlag, "", "Client id to be used for sending data")
 	flags.String(common.ClientSecretFlag, "", "Client secret to be used for sending data")
 	flags.Bool(sim.QuietFlag, false, "don't spam stderr")
-	flags.StringSlice(sim.ConsentLevelsFlag, []string{"", "0", "0/1", "0/1/2", "0/1/2/3"}, "consent levels to be simulated")
+	flags.StringSlice(sim.PurposeLevelsFlag, []string{"", "0", "0/1", "0/1/2", "0/1/2/3"}, "purpose levels to be simulated (these used to be called consent levels)")
 	return simCmd
 }

--- a/pkg/simulator/random_events/event_generators.go
+++ b/pkg/simulator/random_events/event_generators.go
@@ -7,11 +7,11 @@ import (
 	"strmprivacy/strm/pkg/simulator"
 )
 
-func createRandomDemoEvent(consentLevels []int32, sessionId string) sim.StrmPrivacyEvent {
+func createRandomDemoEvent(purposeLevels []int32, sessionId string) sim.StrmPrivacyEvent {
 	event := demoschema.NewDemoEvent()
 	const eventContractRef = "strmprivacy/example/1.3.0"
 	event.StrmMeta = &demoschema.StrmMeta{
-		ConsentLevels:    consentLevels,
+		ConsentLevels:    purposeLevels,
 		EventContractRef: eventContractRef,
 	}
 	event.ConsistentValue = sessionId

--- a/pkg/simulator/random_events/randomsim.go
+++ b/pkg/simulator/random_events/randomsim.go
@@ -8,13 +8,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
-	"github.com/strmprivacy/api-definitions-go/v2/api/entities/v1"
 	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 	"strmprivacy/strm/pkg/entity/stream"
-	"strmprivacy/strm/pkg/simulator"
+	sim "strmprivacy/strm/pkg/simulator"
 	"strmprivacy/strm/pkg/util"
+
+	"github.com/spf13/cobra"
+	"github.com/strmprivacy/api-definitions-go/v2/api/entities/v1"
 )
 
 // start a random simulator
@@ -42,7 +43,7 @@ func run(cmd *cobra.Command, streamName *string) {
 	sessionPrefix := util.GetStringAndErr(flags, sim.SessionPrefixFlag)
 	gateway := util.GetStringAndErr(flags, sim.EventsApiUrlFlag)
 	quiet := util.GetBoolAndErr(flags, sim.QuietFlag)
-	consentLevels, err := flags.GetStringSlice(sim.ConsentLevelsFlag)
+	purposeLevels, err := flags.GetStringSlice(sim.PurposeLevelsFlag)
 	common.CliExit(err)
 
 	schema := util.GetStringAndErr(flags, sim.SchemaFlag)
@@ -51,8 +52,8 @@ func run(cmd *cobra.Command, streamName *string) {
 		common.CliExit(errors.New(fmt.Sprintf("Can't simulate for schema %s", schema)))
 	}
 
-	if len(consentLevels) == 0 {
-		common.CliExit(errors.New(fmt.Sprintf("%v is not a valid set of consent levels", consentLevels)))
+	if len(purposeLevels) == 0 {
+		common.CliExit(errors.New(fmt.Sprintf("%v is not a valid set of purpose levels", purposeLevels)))
 	}
 
 	if !quiet {
@@ -69,7 +70,7 @@ func run(cmd *cobra.Command, streamName *string) {
 	now := time.Now()
 	for {
 		sessionId := fmt.Sprintf("%s-%d", sessionPrefix, rand.Intn(sessionRange))
-		event := f(randomConsentLevels(consentLevels), sessionId)
+		event := f(randomConsentLevels(purposeLevels), sessionId)
 		token := auth.GetEventToken(s.Ref.BillingId, s.Credentials[0].ClientId, s.Credentials[0].ClientSecret)
 
 		go sender.Send(event, token)

--- a/pkg/simulator/sims.go
+++ b/pkg/simulator/sims.go
@@ -14,7 +14,7 @@ const (
 	EventsApiUrlFlag  = "events-api-url"
 	SessionRangeFlag  = "session-range"
 	SessionPrefixFlag = "session-prefix"
-	ConsentLevelsFlag = "consent-levels"
+	PurposeLevelsFlag = "purpose-levels"
 	QuietFlag         = "quiet"
 	SchemaFlag        = "schema"
 )

--- a/pkg/util/printers.go
+++ b/pkg/util/printers.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"os"
+	"strings"
 	"strmprivacy/strm/pkg/common"
 )
 
@@ -140,4 +141,7 @@ var noBordersStyle = table.Style{
 		TopSeparator:     " ",
 		UnfinishedRow:    "...",
 	},
+}
+func ReplaceConsent(consentLevelType string) string {
+	return strings.Replace(consentLevelType, "CONSENT", "PURPOSE", -1)
 }


### PR DESCRIPTION
Just a rename in the interface
```
dstrm list streams
 STREAM                DERIVED   PURPOSE LEVEL TYPE   PURPOSE LEVELS   ENABLED

 sim-deterministic-1   true      CUMULATIVE           [1]              true
 sim-deterministic-2   true      CUMULATIVE           [2]              true
 sim-deterministic-3   true      CUMULATIVE           [3]              true
 sim-deterministic     false                          []               true
```
Adding `-o json` would still show the original `consentLevels`.