### PR TITLE
exposes account info via `strm context account`

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -23,6 +23,7 @@ import (
 	"strmprivacy/strm/pkg/entity/schema_code"
 	"strmprivacy/strm/pkg/entity/stream"
 	"strmprivacy/strm/pkg/entity/usage"
+	"strmprivacy/strm/pkg/entity/account"
 	"strmprivacy/strm/pkg/util"
 )
 
@@ -63,6 +64,7 @@ func SetupServiceClients(accessToken *string) {
 	event_contract.SetupClient(clientConnection, ctx)
 	usage.SetupClient(clientConnection, ctx)
 	installation.SetupClient(clientConnection, ctx)
+	account.SetupClient(clientConnection, ctx)
 }
 
 func ConfigPath() string {

--- a/pkg/cmd/context.go
+++ b/pkg/cmd/context.go
@@ -15,4 +15,5 @@ func init() {
 	ContextCommand.AddCommand(context.Configuration())
 	ContextCommand.AddCommand(context.EntityInfo())
 	ContextCommand.AddCommand(context.BillingIdInfo())
+	ContextCommand.AddCommand(context.Account())
 }

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -63,3 +63,6 @@ var ConfigOutputFormatFlagAllowedValuesText = strings.Join(ConfigOutputFormatFla
 
 var BillingIdOutputFormatFlagAllowedValues = []string{OutputFormatPlain}
 var BillingIdOutputFormatFlagAllowedValuesText = strings.Join(BillingIdOutputFormatFlagAllowedValues, ", ")
+
+var AccountOutputFormatFlagAllowedValues = []string{OutputFormatPlain, OutputFormatJsonRaw}
+var AccountOutputFormatFlagAllowedValuesText = strings.Join(AccountOutputFormatFlagAllowedValues, ", ")

--- a/pkg/context/cmd.go
+++ b/pkg/context/cmd.go
@@ -2,10 +2,9 @@ package context
 
 import (
 	"fmt"
+	"github.com/spf13/cobra"
 	"path"
 	"strmprivacy/strm/pkg/auth"
-
-	"github.com/spf13/cobra"
 	"strmprivacy/strm/pkg/common"
 )
 
@@ -13,6 +12,7 @@ const (
 	configCommandName        = "config"
 	entityInfoCommandName    = "info"
 	billingIdInfoCommandName = "billing-id"
+	accountCommandName       = "account"
 )
 
 func Configuration() *cobra.Command {
@@ -69,6 +69,32 @@ func BillingIdInfo() *cobra.Command {
 	common.CliExit(err)
 	return cmd
 }
+
+func Account() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               accountCommandName,
+		Short:             "Show the handle of this account",
+		DisableAutoGenTag: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			printer = configurePrinter(cmd)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			getHandle()
+		},
+	}
+	cmd.Flags().StringP(
+		common.OutputFormatFlag,
+		common.OutputFormatFlagShort,
+		common.OutputFormatJsonRaw,
+		fmt.Sprintf("Configuration output format [%v]", common.AccountOutputFormatFlagAllowedValuesText),
+	)
+	err := cmd.RegisterFlagCompletionFunc(common.OutputFormatFlag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return common.AccountOutputFormatFlagAllowedValues, cobra.ShellCompDirectiveNoFileComp
+	})
+	common.CliExit(err)
+	return cmd
+}
+
 
 func EntityInfo() *cobra.Command {
 	entityInfo := &cobra.Command{

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
+	"strmprivacy/strm/pkg/entity/account"
 )
 
 type configuration struct {
@@ -58,6 +59,10 @@ func entityInfo(args []string) {
 	printer.Print(entity)
 }
 
+func getHandle() {
+	details := account.GetHandle()
+	printer.Print(details)
+}
 func billingIdInfo() {
 	b, err := auth.GetBillingId()
 	if err != nil {

--- a/pkg/entity/account/account.go
+++ b/pkg/entity/account/account.go
@@ -1,0 +1,27 @@
+package account
+
+import (
+	"context"
+	"github.com/strmprivacy/api-definitions-go/v2/api/account/v1"
+	"google.golang.org/grpc"
+	"strmprivacy/strm/pkg/auth"
+	"strmprivacy/strm/pkg/common"
+)
+
+
+var client account.AccountServiceClient
+var apiContext context.Context
+
+func SetupClient(clientConnection *grpc.ClientConn, ctx context.Context) {
+	apiContext = ctx
+	client = account.NewAccountServiceClient(clientConnection)
+}
+
+func GetHandle() *account.GetAccountDetailsResponse {
+	req := &account.GetAccountDetailsRequest{
+		BillingId: auth.Auth.BillingId(),
+	}
+	details, err := client.GetAccountDetails(apiContext, req)
+	common.CliExit(err)
+	return details
+}

--- a/pkg/entity/schema_code/cmd.go
+++ b/pkg/entity/schema_code/cmd.go
@@ -1,8 +1,9 @@
 package schema_code
 
 import (
-	"github.com/spf13/cobra"
 	"strmprivacy/strm/pkg/entity/schema"
+
+	"github.com/spf13/cobra"
 )
 
 var longDoc = `In order to simplify sending correctly serialized data to STRM Privacy it is recommended to use generated source code
@@ -39,5 +40,5 @@ func GetCmd() *cobra.Command {
 }
 
 func languageCompletion(cmd *cobra.Command, args []string, complete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"java", "typescript", "python"}, cobra.ShellCompDirectiveDefault
+	return []string{"java", "typescript", "python", "rust"}, cobra.ShellCompDirectiveDefault
 }


### PR DESCRIPTION
```
strm context account -o plain
billing_id: mybillingid
max_input_streams: -1
handle: myhandle
subscription: SELF_HOSTED
```
or
```
strm context account -o json-raw  | jq
{
  "billing_id": "anotherone",
  "max_input_streams": 1,
  "handle": "handletest",
  "subscription": "FREE"
}
```