### PR TITLE
feat(strm-1238): remove (almost) all billingId usages

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,7 +25,7 @@ jobs:
           make
       - name: Run CLI tests
         env:
-          STRM_TEST_USER_BILLING_ID: ${{ secrets.STRM_TEST_USER_BILLING_ID }}
+          STRM_TEST_PROJECT: ${{ secrets.STRM_TEST_PROJECT }}
           STRM_TEST_USER_EMAIL: ${{ secrets.STRM_TEST_USER_EMAIL }}
           STRM_TEST_USER_PASSWORD: ${{ secrets.STRM_TEST_USER_PASSWORD }}
           STRM_TEST_S3_USER_NAME: ${{ secrets.STRM_TEST_S3_USER_NAME }}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.0
-	github.com/strmprivacy/api-definitions-go/v2 v2.38.0
+	github.com/strmprivacy/api-definitions-go/v2 v2.43.1
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.46.0

--- a/go.sum
+++ b/go.sum
@@ -411,8 +411,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/strmprivacy/api-definitions-go/v2 v2.38.0 h1:/d6oh2xc0N249j0LSAjbi2nLfY30dcaA6BYcprHMWYk=
-github.com/strmprivacy/api-definitions-go/v2 v2.38.0/go.mod h1:3uFjMuBEQSzrRQzaKEgIrLbBWRdya9DTYCQZqyS7nEw=
+github.com/strmprivacy/api-definitions-go/v2 v2.43.1 h1:saiY1lAElmviKOv8e0IjQGpoitypMFHqglWjp1Za3DU=
+github.com/strmprivacy/api-definitions-go/v2 v2.43.1/go.mod h1:3uFjMuBEQSzrRQzaKEgIrLbBWRdya9DTYCQZqyS7nEw=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/auth/cmd.go
+++ b/pkg/auth/cmd.go
@@ -6,7 +6,7 @@ import (
 
 var longDocPrintToken = `
 Print the current (JWT) access token to the terminal that can be used in a http header. Note that the token is printed
-on ` + "`stdout`" + `, and the Expiry and billing-id are on ` + "`stderr`" + ` so it’s easy to capture the token for scripting use with
+on ` + "`stdout`" + `, and the Expiry on ` + "`stderr`" + ` so it’s easy to capture the token for scripting use with
 
 ` + "```" + `bash
 export token=$(strm auth access-token)

--- a/pkg/auth/stored_token.go
+++ b/pkg/auth/stored_token.go
@@ -21,7 +21,6 @@ type storedToken struct {
 	AccessToken  string `json:"accessToken"`
 	RefreshToken string `json:"refreshToken"`
 	ExpiresAt    int64  `json:"expiresAt"`
-	BillingId    string `json:"billingId"`
 	Email        string `json:"email"`
 }
 
@@ -52,7 +51,6 @@ func (authenticator *Authenticator) LoadLogin() error {
 func (authenticator *Authenticator) populateValues(storedToken storedToken) {
 	authenticator.storedToken = storedToken
 	authenticator.tokenSource = createTokenSource(authenticator.storedToken)
-	authenticator.billingId = &authenticator.storedToken.BillingId
 	authenticator.Email = authenticator.storedToken.Email
 }
 
@@ -97,15 +95,4 @@ func createTokenSource(storedToken storedToken) oauth2.TokenSource {
 	oAuth2Config := oAuth2Config()
 	tokenSource := oAuth2Config.TokenSource(ctx, oauth2Token)
 	return tokenSource
-}
-
-func GetBillingId() (string, error) {
-	filename := (&Authenticator{}).getSaveFilename()
-	b, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return "", err
-	}
-	token := unmarshalStoredToken(err, b)
-	billingId := token.BillingId
-	return billingId, err
 }

--- a/pkg/cmd/context.go
+++ b/pkg/cmd/context.go
@@ -14,7 +14,6 @@ var ContextCommand = &cobra.Command{
 func init() {
 	ContextCommand.AddCommand(context.Configuration())
 	ContextCommand.AddCommand(context.EntityInfo())
-	ContextCommand.AddCommand(context.BillingIdInfo())
 	ContextCommand.AddCommand(context.Account())
 	ContextCommand.AddCommand(context.Project())
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -91,13 +91,6 @@ func MissingIdTokenError() {
 	CliExit(errors.New(fmt.Sprintf("No login information found. Use: `%v auth login` first.", RootCommandName)))
 }
 
-func MissingBillingIdCompletionError(commandPath string) ([]string, cobra.ShellCompDirective) {
-	log.Infoln(fmt.Sprintf("Called '%v' without login info", commandPath))
-	cobra.CompErrorln(fmt.Sprintf("No login information found. Use: `%v auth login` first.", RootCommandName))
-
-	return nil, cobra.ShellCompDirectiveNoFileComp
-}
-
 func GrpcRequestCompletionError(err error) ([]string, cobra.ShellCompDirective) {
 	errorMessage := fmt.Sprintf("%v", err)
 	log.Errorln(errorMessage)

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -61,9 +61,6 @@ var ContextOutputFormatFlagAllowedValuesText = strings.Join(ContextOutputFormatF
 var ConfigOutputFormatFlagAllowedValues = []string{OutputFormatPlain, OutputFormatJson}
 var ConfigOutputFormatFlagAllowedValuesText = strings.Join(ConfigOutputFormatFlagAllowedValues, ", ")
 
-var BillingIdOutputFormatFlagAllowedValues = []string{OutputFormatPlain}
-var BillingIdOutputFormatFlagAllowedValuesText = strings.Join(BillingIdOutputFormatFlagAllowedValues, ", ")
-
 var AccountOutputFormatFlagAllowedValues = []string{OutputFormatPlain, OutputFormatJsonRaw}
 var AccountOutputFormatFlagAllowedValuesText = strings.Join(AccountOutputFormatFlagAllowedValues, ", ")
 

--- a/pkg/context/cmd.go
+++ b/pkg/context/cmd.go
@@ -4,14 +4,12 @@ import (
 	"fmt"
 	"github.com/spf13/cobra"
 	"path"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 )
 
 const (
 	configCommandName        = "config"
 	entityInfoCommandName    = "info"
-	billingIdInfoCommandName = "billing-id"
 	accountCommandName       = "account"
 	projectCommandName 	     = "project"
 )
@@ -42,33 +40,6 @@ func Configuration() *cobra.Command {
 	common.CliExit(err)
 
 	return configuration
-}
-
-func BillingIdInfo() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:               billingIdInfoCommandName,
-		Short:             "Show the billing id.",
-		DisableAutoGenTag: true,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			printer = configurePrinter(cmd)
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			_ = auth.Auth.BillingId()
-			billingIdInfo()
-		},
-	}
-	cmd.Flags().StringP(
-		common.OutputFormatFlag,
-		common.OutputFormatFlagShort,
-		common.OutputFormatPlain,
-		common.BillingIdOutputFormatFlagAllowedValuesText,
-	)
-	err := cmd.RegisterFlagCompletionFunc(common.OutputFormatFlag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return common.BillingIdOutputFormatFlagAllowedValues, cobra.ShellCompDirectiveNoFileComp
-	})
-
-	common.CliExit(err)
-	return cmd
 }
 
 func Account() *cobra.Command {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,9 +1,7 @@
 package context
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"path"
 	"strings"
@@ -64,17 +62,6 @@ func entityInfo(args []string) {
 func showAccountDetails() {
 	details := account.GetAccountDetails()
 	printer.Print(details)
-}
-
-func billingIdInfo() {
-	b, err := auth.GetBillingId()
-	if err != nil {
-		if fileError, ok := err.(*fs.PathError); ok {
-			common.CliExit(errors.New(fmt.Sprintf("Can't %s %s", fileError.Op, fileError.Path)))
-		}
-	}
-	common.CliExit(err)
-	printer.Print(b)
 }
 
 func listSavedEntities(p string) []string {

--- a/pkg/context/printers.go
+++ b/pkg/context/printers.go
@@ -29,8 +29,6 @@ func configurePrinter(command *cobra.Command) util.Printer {
 			allowedValues = common.ContextOutputFormatFlagAllowedValuesText
 		case configCommandName:
 			allowedValues = common.ConfigOutputFormatFlagAllowedValuesText
-		case billingIdInfoCommandName:
-			allowedValues = common.ConfigOutputFormatFlagAllowedValuesText
 		case accountCommandName:
 			allowedValues = common.ConfigOutputFormatFlagAllowedValuesText
 		case projectCommandName:
@@ -50,7 +48,6 @@ func availablePrinters() map[string]util.Printer {
 		common.OutputFormatFilepath + entityInfoCommandName: filepathPrinter{},
 		common.OutputFormatPlain + configCommandName:        configPlainPrinter{},
 		common.OutputFormatJson + configCommandName:         configJsonPrinter{},
-		common.OutputFormatPlain + billingIdInfoCommandName: billingIdPrinter{},
 		common.OutputFormatJsonRaw + accountCommandName:     accountJsonPrinter{},
 		common.OutputFormatPlain + accountCommandName:       accountPlainPrinter{},
 		common.OutputFormatPlain + projectCommandName:       projectPrinter{},
@@ -64,7 +61,6 @@ type configPlainPrinter struct{}
 type accountJsonPrinter struct{}
 type accountPlainPrinter struct{}
 type configJsonPrinter struct{}
-type billingIdPrinter struct{}
 type projectPrinter struct{}
 
 func (p filepathPrinter) Print(data interface{}) {
@@ -94,7 +90,6 @@ func (p accountJsonPrinter) Print(data interface{}) {
 
 func (p accountPlainPrinter) Print(data interface{}) {
 	entity, _ := (data).(*account.GetAccountDetailsResponse)
-	fmt.Println(fmt.Sprintf("billing_id: %v", entity.BillingId))
 	fmt.Println(fmt.Sprintf("max_input_streams: %v", entity.MaxInputStreams))
 	fmt.Println(fmt.Sprintf("handle: %v", entity.Handle))
 	fmt.Println(fmt.Sprintf("subscription: %v", entity.Subscription))
@@ -126,10 +121,6 @@ func (p configJsonPrinter) Print(data interface{}) {
 	b, _ := json.Marshal(entity)
 	rawJson := util.CompactJson(b)
 	fmt.Println(string(rawJson.Bytes()))
-}
-
-func (p billingIdPrinter) Print(data interface{}) {
-	fmt.Println(data)
 }
 
 func (p projectPrinter) Print(data interface{}) {

--- a/pkg/entity/batch_exporter/batch_exporter.go
+++ b/pkg/entity/batch_exporter/batch_exporter.go
@@ -13,7 +13,6 @@ import (
 	"github.com/strmprivacy/api-definitions-go/v2/api/batch_exporters/v1"
 	"github.com/strmprivacy/api-definitions-go/v2/api/entities/v1"
 	"google.golang.org/grpc"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 	"strmprivacy/strm/pkg/util"
 )
@@ -28,7 +27,6 @@ func SetupClient(clientConnection *grpc.ClientConn, ctx context.Context) {
 
 func list() {
 	req := &batch_exporters.ListBatchExportersRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 	}
 	response, err := client.ListBatchExporters(apiContext, req)
@@ -39,7 +37,6 @@ func list() {
 
 func get(name *string, _ *cobra.Command) {
 	ref := &entities.BatchExporterRef{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		Name:      *name,
 	}
@@ -51,7 +48,6 @@ func get(name *string, _ *cobra.Command) {
 
 func del(name *string) {
 	req := &batch_exporters.DeleteBatchExporterRequest{Ref: &entities.BatchExporterRef{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		Name:      *name,
 	}}
@@ -75,12 +71,10 @@ func create(streamName *string, cmd *cobra.Command) {
 
 	exporter := &entities.BatchExporter{
 		Ref: &entities.BatchExporterRef{
-			BillingId: auth.Auth.BillingId(),
 			ProjectId: common.ProjectId,
 			Name:      exporterName,
 		},
 		DataConnectorRef: &entities.DataConnectorRef{
-			BillingId: auth.Auth.BillingId(),
 			ProjectId: common.ProjectId,
 			Name:      dataConnectorName,
 		},
@@ -91,14 +85,12 @@ func create(streamName *string, cmd *cobra.Command) {
 	if keyStream {
 		exporter.StreamOrKeyStreamRef = &entities.BatchExporter_KeyStreamRef{
 			KeyStreamRef: &entities.KeyStreamRef{
-				BillingId: auth.Auth.BillingId(),
 				ProjectId: common.ProjectId,
 				Name:      *streamName,
 			}}
 	} else {
 		exporter.StreamOrKeyStreamRef = &entities.BatchExporter_StreamRef{
 			StreamRef: &entities.StreamRef{
-				BillingId: auth.Auth.BillingId(),
 				ProjectId: common.ProjectId,
 				Name:      *streamName,
 			}}
@@ -132,7 +124,6 @@ func getDataConnectorName(flags *pflag.FlagSet) string {
 
 func getDataConnectorNames() []string {
 	req := &data_connectors.ListDataConnectorsRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 	}
 	response, err := data_connector.Client.ListDataConnectors(apiContext, req)
@@ -152,11 +143,7 @@ func namesCompletion(cmd *cobra.Command, args []string, complete string) ([]stri
 		// this one means you don't get multiple completion suggestions for one stream if it's not a delete call
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	if auth.Auth.BillingIdAbsent() {
-		return common.MissingBillingIdCompletionError(cmd.CommandPath())
-	}
 	req := &batch_exporters.ListBatchExportersRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 	}
 	response, err := client.ListBatchExporters(apiContext, req)

--- a/pkg/entity/batch_job/batch_job.go
+++ b/pkg/entity/batch_job/batch_job.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc"
 	"io/ioutil"
 	"strings"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 	"strmprivacy/strm/pkg/util"
 )
@@ -25,7 +24,6 @@ func SetupClient(clientConnection *grpc.ClientConn, ctx context.Context) {
 
 func list() {
 	req := &batch_jobs.ListBatchJobsRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 	}
 	response, err := client.ListBatchJobs(apiContext, req)
@@ -36,7 +34,6 @@ func list() {
 
 func get(id *string, _ *cobra.Command) {
 	ref := &entities.BatchJobRef{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		Id:        *id,
 	}
@@ -49,7 +46,6 @@ func get(id *string, _ *cobra.Command) {
 func del(id *string) {
 	req := &batch_jobs.DeleteBatchJobRequest{
 		Ref: &entities.BatchJobRef{
-			BillingId: auth.Auth.BillingId(),
 			ProjectId: common.ProjectId,
 			Id: *id,
 		},
@@ -75,7 +71,6 @@ func create(cmd *cobra.Command) {
 	}
 
 	createBatchJobRequest := &batch_jobs.CreateBatchJobRequest{BatchJob: batchJob}
-	batchJob.Ref.BillingId = auth.Auth.BillingId()
 	batchJob.Ref.ProjectId = common.ProjectId
 
 	response, err := client.CreateBatchJob(apiContext, createBatchJobRequest)
@@ -89,11 +84,7 @@ func namesCompletion(cmd *cobra.Command, args []string, complete string) ([]stri
 		// this one means you don't get multiple completion suggestions for one stream if it's not a delete call
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	if auth.Auth.BillingIdAbsent() {
-		return common.MissingBillingIdCompletionError(cmd.CommandPath())
-	}
 	req := &batch_jobs.ListBatchJobsRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 	}
 	response, err := client.ListBatchJobs(apiContext, req)

--- a/pkg/entity/data_connector/cmd.go
+++ b/pkg/entity/data_connector/cmd.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/strmprivacy/api-definitions-go/v2/api/data_connectors/v1"
 	"strings"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 )
 
@@ -86,15 +85,11 @@ func CreateCmd() *cobra.Command {
 }
 
 func NamesCompletion(cmd *cobra.Command, args []string, complete string) ([]string, cobra.ShellCompDirective) {
-	if auth.Auth.BillingIdAbsent() {
-		return common.MissingBillingIdCompletionError(cmd.CommandPath())
-	}
 	if len(args) != 0 && strings.Fields(cmd.Short)[0] != "Delete" {
 		// this one means you don't get multiple completion suggestions for one stream if it's not a delete call
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	req := &data_connectors.ListDataConnectorsRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 	}
 	response, err := Client.ListDataConnectors(apiContext, req)

--- a/pkg/entity/data_connector/data_connector.go
+++ b/pkg/entity/data_connector/data_connector.go
@@ -7,7 +7,6 @@ import (
 	"github.com/strmprivacy/api-definitions-go/v2/api/entities/v1"
 	"google.golang.org/grpc"
 	"io/ioutil"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 	"strmprivacy/strm/pkg/util"
 )
@@ -22,7 +21,6 @@ func SetupClient(clientConnection *grpc.ClientConn, ctx context.Context) {
 
 func list(recursive bool) {
 	req := &data_connectors.ListDataConnectorsRequest{
-		BillingId:          auth.Auth.BillingId(),
 		ProjectId:          common.ProjectId,
 		Recursive:          recursive,
 		IncludeCredentials: false,
@@ -64,7 +62,6 @@ func create(dataConnector *entities.DataConnector) {
 
 func ref(name *string) *entities.DataConnectorRef {
 	return &entities.DataConnectorRef{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		Name: *name,
 	}

--- a/pkg/entity/event_contract/event_contract.go
+++ b/pkg/entity/event_contract/event_contract.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/grpc"
 	"io/ioutil"
 	"strings"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 	"strmprivacy/strm/pkg/entity/schema"
 	"strmprivacy/strm/pkg/util"
@@ -53,9 +52,7 @@ func SetupClient(clientConnection *grpc.ClientConn, ctx context.Context) {
 }
 
 func list() {
-	req := &event_contracts.ListEventContractsRequest{
-		BillingId: auth.Auth.BillingId(),
-	}
+	req := &event_contracts.ListEventContractsRequest{}
 	response, err := client.ListEventContracts(apiContext, req)
 	common.CliExit(err)
 	printer.Print(response)
@@ -63,7 +60,6 @@ func list() {
 
 func del(name *string) {
 	req := &event_contracts.DeleteEventContractRequest{
-		BillingId:        auth.Auth.BillingId(),
 		ProjectId:        common.ProjectId,
 		EventContractRef: ref(name)}
 	response, err := client.DeleteEventContract(apiContext, req)
@@ -74,7 +70,6 @@ func del(name *string) {
 
 func activate(name *string) {
 	req := &event_contracts.ActivateEventContractRequest{
-		BillingId:        auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		EventContractRef: ref(name)}
 	response, err := client.ActivateEventContract(apiContext, req)
@@ -85,7 +80,6 @@ func activate(name *string) {
 
 func archive(name *string) {
 	req := &event_contracts.ArchiveEventContractRequest{
-		BillingId:        auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		EventContractRef: ref(name)}
 	response, err := client.ArchiveEventContract(apiContext, req)
@@ -96,7 +90,6 @@ func archive(name *string) {
 
 func get(name *string) {
 	req := &event_contracts.GetEventContractRequest{
-		BillingId: auth.Auth.BillingId(),
 		Ref:       ref(name)}
 	response, err := client.GetEventContract(apiContext, req)
 	common.CliExit(err)
@@ -113,7 +106,6 @@ func create(cmd *cobra.Command, contractReference *string) {
 	definition := readContractDefinition(&definitionFilename)
 
 	req := &event_contracts.CreateEventContractRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		EventContract: &entities.EventContract{
 			Ref:         ref(contractReference),
@@ -142,15 +134,12 @@ func readContractDefinition(filename *string) EventContractDefinition {
 }
 
 func RefsCompletion(cmd *cobra.Command, args []string, complete string) ([]string, cobra.ShellCompDirective) {
-	if auth.Auth.BillingIdAbsent() {
-		return common.MissingBillingIdCompletionError(cmd.CommandPath())
-	}
 	if len(args) != 0 {
 		// this one means you don't get multiple completion suggestions for one stream
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	req := &event_contracts.ListEventContractsRequest{BillingId: auth.Auth.BillingId()}
+	req := &event_contracts.ListEventContractsRequest{}
 	response, err := client.ListEventContracts(apiContext, req)
 
 	if err != nil {

--- a/pkg/entity/installation/installation.go
+++ b/pkg/entity/installation/installation.go
@@ -5,7 +5,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/strmprivacy/api-definitions-go/v2/api/installations/v1"
 	"google.golang.org/grpc"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 )
 
@@ -32,9 +31,6 @@ func list() {
 }
 
 func namesCompletion(cmd *cobra.Command, args []string, complete string) ([]string, cobra.ShellCompDirective) {
-	if auth.Auth.BillingIdAbsent() {
-		return common.MissingBillingIdCompletionError(cmd.CommandPath())
-	}
 	if len(args) != 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/pkg/entity/kafka_cluster/kafka_cluster.go
+++ b/pkg/entity/kafka_cluster/kafka_cluster.go
@@ -7,7 +7,6 @@ import (
 	"github.com/strmprivacy/api-definitions-go/v2/api/entities/v1"
 	"github.com/strmprivacy/api-definitions-go/v2/api/kafka_clusters/v1"
 	"google.golang.org/grpc"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 )
 
@@ -19,7 +18,6 @@ var apiContext context.Context
 
 func ref(n *string) *entities.KafkaClusterRef {
 	return &entities.KafkaClusterRef{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		Name: *n,
 	}
@@ -32,7 +30,6 @@ func SetupClient(clientConnection *grpc.ClientConn, ctx context.Context) {
 
 func list() {
 	req := &kafka_clusters.ListKafkaClustersRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 	}
 	response, err := client.ListKafkaClusters(apiContext, req)
@@ -49,16 +46,12 @@ func get(name *string) {
 }
 
 func NamesCompletion(cmd *cobra.Command, args []string, complete string) ([]string, cobra.ShellCompDirective) {
-	if auth.Auth.BillingIdAbsent() {
-		return common.MissingBillingIdCompletionError(cmd.CommandPath())
-	}
 	if len(args) != 0 {
 		// this one means you don't get multiple completion suggestions for one stream
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	req := &kafka_clusters.ListKafkaClustersRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 	}
 	response, err := client.ListKafkaClusters(apiContext, req)
@@ -76,5 +69,5 @@ func NamesCompletion(cmd *cobra.Command, args []string, complete string) ([]stri
 }
 
 func RefToString(clusterRef *entities.KafkaClusterRef) string {
-	return fmt.Sprintf("%v/%v", clusterRef.BillingId, clusterRef.Name)
+	return fmt.Sprintf("%v", clusterRef.Name)
 }

--- a/pkg/entity/kafka_exporter/kafka_exporter.go
+++ b/pkg/entity/kafka_exporter/kafka_exporter.go
@@ -7,7 +7,6 @@ import (
 	"github.com/strmprivacy/api-definitions-go/v2/api/kafka_exporters/v1"
 	"google.golang.org/grpc"
 	"strings"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 	"strmprivacy/strm/pkg/util"
 )
@@ -23,7 +22,6 @@ func SetupClient(clientConnection *grpc.ClientConn, ctx context.Context) {
 func Get(name *string) *kafka_exporters.GetKafkaExporterResponse {
 	req := &kafka_exporters.GetKafkaExporterRequest{
 		Ref: &entities.KafkaExporterRef{
-			BillingId: auth.Auth.BillingId(),
 			ProjectId: common.ProjectId,
 			Name: *name,
 		},
@@ -36,7 +34,6 @@ func Get(name *string) *kafka_exporters.GetKafkaExporterResponse {
 func list(recursive bool) {
 	// TODO need api recursive addition
 	req := &kafka_exporters.ListKafkaExportersRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 	}
 	response, err := client.ListKafkaExporters(apiContext, req)
@@ -51,7 +48,6 @@ func get(name *string, recursive bool) {
 
 func del(name *string, recursive bool) {
 	exporterRef := &entities.KafkaExporterRef{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		Name: *name,
 	}
@@ -76,12 +72,10 @@ func create(name *string, cmd *cobra.Command) {
 	// key streams not yet supported in data model!
 	exporter := &entities.KafkaExporter{
 		StreamRef: &entities.StreamRef{
-			BillingId: auth.Auth.BillingId(),
 			ProjectId: common.ProjectId,
 			Name: *name,
 		},
 		Ref:       &entities.KafkaExporterRef{
-			BillingId: auth.Auth.BillingId(),
 			ProjectId: common.ProjectId,
 		},
 	}
@@ -103,16 +97,12 @@ func create(name *string, cmd *cobra.Command) {
 }
 
 func NamesCompletion(cmd *cobra.Command, args []string, complete string) ([]string, cobra.ShellCompDirective) {
-	if auth.Auth.BillingIdAbsent() {
-		return common.MissingBillingIdCompletionError(cmd.CommandPath())
-	}
 	if len(args) != 0 && strings.Fields(cmd.Short)[0] != "Delete" {
 		// this one means you don't get multiple completion suggestions for one stream if it's not a delete call
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	req := &kafka_exporters.ListKafkaExportersRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 	}
 	response, err := client.ListKafkaExporters(apiContext, req)

--- a/pkg/entity/kafka_user/kafka_user.go
+++ b/pkg/entity/kafka_user/kafka_user.go
@@ -7,7 +7,6 @@ import (
 	"github.com/strmprivacy/api-definitions-go/v2/api/kafka_users/v1"
 	"google.golang.org/grpc"
 	"strings"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 	"strmprivacy/strm/pkg/entity/kafka_exporter"
 	"strmprivacy/strm/pkg/util"
@@ -18,7 +17,6 @@ var apiContext context.Context
 
 func ref(n *string) *entities.KafkaUserRef {
 	return &entities.KafkaUserRef{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		Name: *n,
 	}
@@ -32,7 +30,6 @@ func SetupClient(clientConnection *grpc.ClientConn, ctx context.Context) {
 func list(exporterName *string) {
 	req := &kafka_users.ListKafkaUsersRequest{
 		Ref: &entities.KafkaExporterRef{
-			BillingId: auth.Auth.BillingId(),
 			ProjectId: common.ProjectId,
 			Name:      *exporterName,
 		},
@@ -65,7 +62,6 @@ func create(kafkaExporterName *string, cmd *cobra.Command) {
 	exporter := kafka_exporter.Get(kafkaExporterName).KafkaExporter
 	kafkaUser := &entities.KafkaUser{
 		Ref: &entities.KafkaUserRef{
-			BillingId: auth.Auth.BillingId(),
 			ProjectId: common.ProjectId,
 		},
 		KafkaExporterName: exporter.Ref.Name,
@@ -84,9 +80,6 @@ func create(kafkaExporterName *string, cmd *cobra.Command) {
 }
 
 func namesCompletion(cmd *cobra.Command, args []string, complete string) ([]string, cobra.ShellCompDirective) {
-	if auth.Auth.BillingIdAbsent() {
-		return common.MissingBillingIdCompletionError(cmd.CommandPath())
-	}
 	if len(args) != 0 && strings.Fields(cmd.Short)[0] != "Delete" {
 		// this one means you don't get multiple completion suggestions for one stream if it's not a delete call
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -94,7 +87,6 @@ func namesCompletion(cmd *cobra.Command, args []string, complete string) ([]stri
 
 	req := &kafka_users.ListKafkaUsersRequest{
 		Ref: &entities.KafkaExporterRef{
-			BillingId: auth.Auth.BillingId(),
 			ProjectId: common.ProjectId,
 		},
 	}

--- a/pkg/entity/key_stream/key_stream.go
+++ b/pkg/entity/key_stream/key_stream.go
@@ -6,7 +6,6 @@ import (
 	"github.com/strmprivacy/api-definitions-go/v2/api/entities/v1"
 	"github.com/strmprivacy/api-definitions-go/v2/api/key_streams/v1"
 	"google.golang.org/grpc"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 )
 
@@ -20,7 +19,6 @@ func SetupClient(clientConnection *grpc.ClientConn, ctx context.Context) {
 
 func list() {
 	req := &key_streams.ListKeyStreamsRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 	}
 	response, err := client.ListKeyStreams(apiContext, req)
@@ -37,23 +35,18 @@ func get(name *string) {
 
 func ref(n *string) *entities.KeyStreamRef {
 	return &entities.KeyStreamRef{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		Name: *n,
 	}
 }
 
 func NamesCompletion(cmd *cobra.Command, args []string, complete string) ([]string, cobra.ShellCompDirective) {
-	if auth.Auth.BillingIdAbsent() {
-		return common.MissingBillingIdCompletionError(cmd.CommandPath())
-	}
 	if len(args) != 0 {
 		// this one means you don't get multiple completion suggestions for one stream
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	req := &key_streams.ListKeyStreamsRequest{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 	}
 	response, err := client.ListKeyStreams(apiContext, req)

--- a/pkg/entity/schema_code/schema_code.go
+++ b/pkg/entity/schema_code/schema_code.go
@@ -7,7 +7,6 @@ import (
 	"github.com/strmprivacy/api-definitions-go/v2/api/schemas/v1"
 	"google.golang.org/grpc"
 	"os"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 	"strmprivacy/strm/pkg/entity/schema"
 	"strmprivacy/strm/pkg/util"
@@ -38,7 +37,6 @@ func GetSchemaCode(cmd *cobra.Command, name *string) string {
 	outputFile := util.GetStringAndErr(flags, filenameFlag)
 	overwrite := util.GetBoolAndErr(flags, overwriteFlag)
 	req := &schemas.GetSchemaCodeRequest{
-		BillingId: auth.Auth.BillingId(),
 		Language:  language,
 		Ref:       schema.Ref(name),
 	}

--- a/pkg/entity/usage/usage.go
+++ b/pkg/entity/usage/usage.go
@@ -14,7 +14,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"strmprivacy/strm/pkg/auth"
 	"strmprivacy/strm/pkg/common"
 	"strmprivacy/strm/pkg/util"
 )
@@ -61,7 +60,6 @@ func get(cmd *cobra.Command, streamName *string) {
 	}
 
 	req := &usage.GetStreamEventUsageRequest{Ref: &entities.StreamRef{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		Name:      *streamName,
 	},

--- a/pkg/simulator/random_events/randomsim.go
+++ b/pkg/simulator/random_events/randomsim.go
@@ -20,7 +20,6 @@ import (
 // start a random simulator
 func run(cmd *cobra.Command, streamName *string) {
 	s := &entities.Stream{Ref: &entities.StreamRef{
-		BillingId: auth.Auth.BillingId(),
 		ProjectId: common.ProjectId,
 		Name: *streamName,
 	}}

--- a/pkg/web_socket/web_socket.go
+++ b/pkg/web_socket/web_socket.go
@@ -19,7 +19,6 @@ const (
 func Run(cmd *cobra.Command, streamName *string) {
 	s := &entities.Stream{
 		Ref: &entities.StreamRef{
-			BillingId: auth.Auth.BillingId(),
 			ProjectId: common.ProjectId,
 			Name: *streamName,
 		},

--- a/test/simple-token.json
+++ b/test/simple-token.json
@@ -1,1 +1,1 @@
-{"idToken":"id.token.test","refreshToken":"refresh.token.test","expiresAt":1625240574,"billingId":"my.billing.id","email":"noreply@strmprivacy.io"}
+{"idToken":"id.token.test","refreshToken":"refresh.token.test","expiresAt":1625240574,"email":"noreply@strmprivacy.io"}

--- a/test/streams_test.go
+++ b/test/streams_test.go
@@ -14,7 +14,7 @@ var streamWithTags, streamWithTagsWithoutSecret *entities.Stream
 
 func init() {
 	streamWithTags = &entities.Stream{
-		Ref:          &entities.StreamRef{BillingId: "testBillingId", Name: "clitest-with-tags", ProjectId: "4800b0ff-0f8c-4333-9b7d-b6d01cb6c9a6"},
+		Ref:          &entities.StreamRef{Name: "clitest-with-tags", ProjectId: testConfig().projectId},
 		Enabled:      true,
 		Limits:       limits,
 		Tags:         []string{"foo", "bar", "baz"},
@@ -42,7 +42,7 @@ func listStreamsTest(t *testing.T) {
 func createStreamTest1(t *testing.T) {
 	expected := &streams.CreateStreamResponse{
 		Stream: &entities.Stream{
-			Ref:          &entities.StreamRef{BillingId: "testBillingId", Name: "clitest", ProjectId: "4800b0ff-0f8c-4333-9b7d-b6d01cb6c9a6"},
+			Ref:          &entities.StreamRef{Name: "clitest", ProjectId: testConfig().projectId},
 			Enabled:      true,
 			Limits:       limits,
 			Credentials:  []*entities.Credentials{creds},
@@ -61,7 +61,7 @@ func createStreamTest2(t *testing.T) {
 func createDerivedStream1(t *testing.T) {
 	expected := &streams.CreateStreamResponse{
 		Stream: &entities.Stream{
-			Ref:              &entities.StreamRef{BillingId: "testBillingId", Name: "clitest-with-tags-2", ProjectId: "4800b0ff-0f8c-4333-9b7d-b6d01cb6c9a6"},
+			Ref:              &entities.StreamRef{Name: "clitest-with-tags-2", ProjectId: testConfig().projectId},
 			ConsentLevels:    []int32{2},
 			ConsentLevelType: entities.ConsentLevelType_CUMULATIVE,
 			Enabled:          true,

--- a/test/test_util.go
+++ b/test/test_util.go
@@ -20,7 +20,7 @@ import (
 )
 
 type TestConfig struct {
-	billingId         string
+	projectId         string
 	email             string
 	password          string
 	s3UserName        string
@@ -35,7 +35,7 @@ func testConfig() *TestConfig {
 		_ = godotenv.Load()
 
 		_testConfig = TestConfig{
-			billingId:         os.Getenv("STRM_TEST_USER_BILLING_ID"),
+			projectId:         os.Getenv("STRM_TEST_PROJECT_ID"),
 			email:             os.Getenv("STRM_TEST_USER_EMAIL"),
 			password:          os.Getenv("STRM_TEST_USER_PASSWORD"),
 			s3UserName:        os.Getenv("STRM_TEST_S3_USER_NAME"),
@@ -75,7 +75,6 @@ type TokenFile struct {
 	IdToken      string `json:"idToken"`
 	RefreshToken string `json:"refreshToken"`
 	ExpiresAt    int    `json:"expiresAt"`
-	BillingId    string `json:"billingId"`
 	Email        string `json:"email"`
 }
 
@@ -145,9 +144,6 @@ func replaceSecretsWithPropertyNames(out string) string {
 
 	s3SecretAccessKeyReplacer := regexp.MustCompile(`SecretAccessKey\\":\\"([^"]+)\\"`)
 	out = s3SecretAccessKeyReplacer.ReplaceAllString(out, `SecretAccessKey\":\"SecretAccessKey\"`)
-
-	testBillingIdReplacer := regexp.MustCompile("(" + testConfig().billingId + ")")
-	out = testBillingIdReplacer.ReplaceAllString(out, "testBillingId")
 
 	return out
 }


### PR DESCRIPTION
BillingId is only kept for event publishing flows (random simulator and web-socket) due to Firebase
auth.