### PR TITLE
feat(strm-1524): show error details for failed batch jobs

### DIFF
--- a/pkg/entity/batch_job/printers.go
+++ b/pkg/entity/batch_job/printers.go
@@ -96,18 +96,27 @@ func printTable(batchJobs []*entities.BatchJob) {
 			return states[j].StateTime.AsTime().Before(states[i].StateTime.AsTime())
 		})
 
+		batchJobState := states[0]
+
+		var message = ""
+		if batchJobState.State == entities.BatchJobStateType_ERROR {
+			message = batchJobState.Message
+		}
+
 		rows = append(rows, table.Row{
 			batchJob.Ref.Id,
-			states[0].State.String(),
-			states[0].StateTime.AsTime(),
+			batchJobState.StateTime.AsTime(),
+			batchJobState.State.String(),
+			message,
 		})
 	}
 
 	util.RenderTable(
 		table.Row{
 			"Batch Job id",
-			"State",
 			"Timestamp",
+			"State",
+			"Details",
 		},
 		rows,
 	)


### PR DESCRIPTION
Example:
```
$ strm list batch-jobs
 BATCH JOB ID                           TIMESTAMP                           STATE      DETAILS

 b96357b9-8d9a-46c9-a51d-66a9460c5897   2022-04-22 12:22:25.915 +0000 UTC   FINISHED
 f69075a9-9d59-4d30-93e0-5138fc22c593   2022-08-19 10:13:49.361 +0000 UTC   ERROR      Event contract example/example/1.0.0 does not have state ACTIVE, but DRAFT. Only active event contracts are allowed
```