### PR TITLE
feat(strm-2399): remove consent level type for derived streams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module strmprivacy/strm
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Shopify/sarama v1.37.2

--- a/pkg/entity/batch_job/texts.go
+++ b/pkg/entity/batch_job/texts.go
@@ -58,7 +58,7 @@ A simplified example Batch Job configuration file
 		  "file_name": "online_retail_II/decrypted-0-small.csv"
 		},
 		"consent_levels": [ 2 ],
-		"consent_level_type": "CUMULATIVE"
+		"consent_level_type": "GRANULAR"
 	  }
 	]
   }

--- a/pkg/entity/stream/cmd.go
+++ b/pkg/entity/stream/cmd.go
@@ -27,11 +27,8 @@ func CreateCmd() *cobra.Command {
 	flags.StringP(linkedStreamFlag, "D", "",
 		"name of stream that this stream is derived from")
 
-	// TODO github.com/thediveo/enumflag might be nicer!
-	flags.String(consentLevelTypeFlag, "CUMULATIVE",
-		"CUMULATIVE or GRANULAR")
-	flags.Int32SliceP(consentLevelsFlag, "L", []int32{},
-		"comma separated list of integers for derived streams")
+	flags.Int32SliceP(purposesFlag, "P", []int32{},
+		"comma separated list of integers referring to purposes (only for derived streams)")
 	flags.String(descriptionFlag, "", "description of this stream")
 	flags.StringSlice(tagsFlag, []string{}, "a list of tags for this stream")
 	flags.Bool(saveFlag, true, "if true, save the credentials in ~/.config/strmprivacy/saved-entities.")

--- a/pkg/entity/stream/printers.go
+++ b/pkg/entity/stream/printers.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
-	"github.com/strmprivacy/api-definitions-go/v2/api/entities/v1"
 	v1 "github.com/strmprivacy/api-definitions-go/v2/api/entities/v1"
 	"github.com/strmprivacy/api-definitions-go/v2/api/streams/v1"
 	"strmprivacy/strm/pkg/common"
@@ -96,18 +95,10 @@ func printTable(streamTreeArray []*v1.StreamTree) {
 	_, m := policy.PoliciesNameIdMap()
 
 	for _, stream := range streamTreeArray {
-		var consentLevelType string
-
-		if stream.Stream.ConsentLevelType != entities.ConsentLevelType_CONSENT_LEVEL_TYPE_UNSPECIFIED {
-			consentLevelType = stream.Stream.ConsentLevelType.String()
-		} else {
-			consentLevelType = ""
-		}
 
 		row := table.Row{
 			stream.Stream.Ref.Name,
 			len(stream.Stream.LinkedStream) != 0,
-			consentLevelType,
 			stream.Stream.ConsentLevels,
 			stream.Stream.Enabled,
 			m[stream.Stream.PolicyId],
@@ -122,8 +113,7 @@ func printTable(streamTreeArray []*v1.StreamTree) {
 	headers := table.Row{
 		"Stream",
 		"Derived",
-		"Consent Level Type",
-		"Consent Levels",
+		"Purposes",
 		"Enabled",
 		"Policy Name",
 	}

--- a/pkg/entity/stream/texts.go
+++ b/pkg/entity/stream/texts.go
@@ -5,24 +5,25 @@ import "strmprivacy/strm/pkg/util"
 var longDocCreate = util.LongDocsUsage(`
 A stream is a pipeline implementation in STRM Privacy using streaming technology (Kafka).
 
-Events are sent to the "Event Gateway" into an "Input Stream", where *all* personal data event attributes are encrypted
-after validating that the event conforms to a data contract. "Privacy Streams" are derived from input streams.
+Events are sent through the "Event Gateway" to a "Source Stream", where *all* sensitive (personal) data event attributes are encrypted
+after validating that the event conforms to a data contract. "Privacy Streams" are derived from source streams.
 
-A derived "Privacy Stream" is configured with one or more consent levels and it only receives events matching those
-consent levels. The PII attributes with matching consent are decrypted, while non-matching attributes remain encrypted.
+A derived "Privacy Stream" is configured for one or more specific purposes. It only receives events that are allowed
+to be processed for the configured purposes. The sensitive attributes matching those purposes are decrypted, while 
+non-matching attributes remain encrypted.
 
-Every stream has its own set of access tokens. Connecting to an input stream requires different credentials than when
-connecting to a derived Privacy Stream.
+Every stream has its own set of access tokens. Connecting to a source stream (i.e. sending events) requires different 
+credentials than connecting to a derived Privacy Stream.
 
 `)
 
 var createExample = `
 strm create stream test
 
-A name is not required for a derived stream; when absent it will be created from the derived stream
-and the consent-levels.
+A name is not required for a derived stream; when absent a name will be created based on the source stream
+and the provided purposes.
 
-strm create stream --derived-from test --levels 1,3,8 --consent-type GRANULAR test-marketing
+strm create stream --derived-from test --purposes 1,3,8 test-marketing
 `
 
 var getExample = util.DedentTrim(`
@@ -46,12 +47,12 @@ strm get stream demo -o json
 `)
 var listExample = util.DedentTrim(`
 strm list streams
- STREAM              DERIVED   CONSENT LEVEL TYPE   CONSENT LEVELS   ENABLED   POLICY NAME
+ STREAM              DERIVED   PURPOSES   ENABLED   POLICY NAME
 
- e-commerce-masked   true      CUMULATIVE           [1]              true
- ecommerce-1         true      CUMULATIVE           [1]              true
- ecommerce           false                          []               true
- ecommerce-2         true      CUMULATIVE           [2]              true
- demo                false                          []               true
- demo-0-1            true      GRANULAR             [0 1]            true
+ e-commerce-masked   true      [1]        true
+ ecommerce-1         true      [1]        true
+ ecommerce           false     []         true
+ ecommerce-2         true      [2]        true
+ demo                false     []         true
+ demo-0-1            true      [0 1]      true
 `)

--- a/pkg/entity/usage/texts.go
+++ b/pkg/entity/usage/texts.go
@@ -6,7 +6,7 @@ var longGetDoc = util.LongDocsUsage(`
 Usage allows you to see how many events were sent on a certain stream. This is currently only the events received on the
 event-gateway. Extracting events via Kafka or Batch exporters is not included.
 
-The values are interpolated from cumulative event accounts, and sampled over intervals
+The values are interpolated from cumulative event counts, and sampled over intervals
 (the --by option). The default output is csv, but json is also available.
 
 The default range is over the last 24 hours, with a default interval of 15 minutes.

--- a/pkg/simulator/random_events/cmd.go
+++ b/pkg/simulator/random_events/cmd.go
@@ -27,7 +27,7 @@ func RunCmd() (cmd *cobra.Command) {
 	flags.Int(SessionRangeFlag, 1000, "number of different sessions being generated")
 	flags.String(SessionPrefixFlag, "session", "prefix string for sessions")
 	flags.Bool(QuietFlag, false, "do not print to stderr")
-	flags.StringSlice(ConsentLevelsFlag, []string{"", "0", "0/1", "0/1/2", "0/1/2/3"}, "consent levels to be simulated")
+	flags.StringSlice(purposesFlag, []string{"", "0", "0/1", "0/1/2", "0/1/2/3"}, "purpose consent to be simulated")
 
 	return simCmd
 }

--- a/pkg/simulator/random_events/random_events.go
+++ b/pkg/simulator/random_events/random_events.go
@@ -22,7 +22,7 @@ const (
 	EventsApiUrlFlag  = "events-api-url"
 	SessionRangeFlag  = "session-range"
 	SessionPrefixFlag = "session-prefix"
-	ConsentLevelsFlag = "consent-levels"
+	purposesFlag      = "purposes"
 	QuietFlag         = "quiet"
 	SchemaFlag        = "schema"
 )
@@ -37,7 +37,7 @@ func randomEvents(cmd *cobra.Command, streamName *string) {
 	sessionPrefix := util.GetStringAndErr(flags, SessionPrefixFlag)
 	gateway := util.GetStringAndErr(flags, EventsApiUrlFlag)
 	quiet := util.GetBoolAndErr(flags, QuietFlag)
-	consentLevels, err := flags.GetStringSlice(ConsentLevelsFlag)
+	purposeConsentLevels, err := flags.GetStringSlice(purposesFlag)
 	common.CliExit(err)
 
 	schema := util.GetStringAndErr(flags, SchemaFlag)
@@ -46,8 +46,8 @@ func randomEvents(cmd *cobra.Command, streamName *string) {
 		common.CliExit(errors.New(fmt.Sprintf("The schema %s is not supported in the CLI", schema)))
 	}
 
-	if len(consentLevels) == 0 {
-		common.CliExit(errors.New(fmt.Sprintf("%v is not a valid set of consent levels", consentLevels)))
+	if len(purposeConsentLevels) == 0 {
+		common.CliExit(errors.New(fmt.Sprintf("%v is not a valid set of purpose levels", purposeConsentLevels)))
 	}
 
 	if !quiet {
@@ -56,7 +56,7 @@ func randomEvents(cmd *cobra.Command, streamName *string) {
 		fmt.Printf("Sending one event every %d ms.\n", interval)
 	}
 
-	simulate(s, gateway, schema, sessionPrefix, sessionRange, consentLevels, interval, quiet)
+	simulate(s, gateway, schema, sessionPrefix, sessionRange, purposeConsentLevels, interval, quiet)
 }
 
 func simulate(s *entities.Stream, gateway string, schema string, sessionPrefix string, sessionRange int, consentLevels []string, interval time.Duration, quiet bool) {

--- a/test/streams_test.go
+++ b/test/streams_test.go
@@ -61,13 +61,13 @@ func createDerivedStream1(t *testing.T) {
 		Stream: &entities.Stream{
 			Ref:              &entities.StreamRef{Name: "clitest-with-tags-2", ProjectId: testConfig().projectId},
 			ConsentLevels:    []int32{2},
-			ConsentLevelType: entities.ConsentLevelType_CUMULATIVE,
+			ConsentLevelType: entities.ConsentLevelType_GRANULAR,
 			Enabled:          true,
 			LinkedStream:     "clitest-with-tags",
 			Credentials:      []*entities.Credentials{creds},
 			MaskedFields:     &entities.MaskedFields{}}}
 	ExecuteAndVerify(t, expected,
-		"create", "stream", "--derived-from=clitest-with-tags", "--levels=2")
+		"create", "stream", "--derived-from=clitest-with-tags", "--purposes=2")
 }
 
 func getStream1(t *testing.T) {


### PR DESCRIPTION
Derived (privacy) streams now use Granular by default. Purposes that may be decrypted by the privacy stream should now each be specified explicitly. For consistency sake, most usages of "consent" or "consent levels" have been renamed to purposes, or similar.