### PR TITLE
fix(strm-2469): correctly handle the absence of an active_projects.json file

### DIFF
--- a/pkg/user_project/user_projects.go
+++ b/pkg/user_project/user_projects.go
@@ -73,6 +73,10 @@ func initializeUsersProjectsContext() {
 		activeProjectFilePath := path.Join(common.ConfigPath(), activeProjectFilename)
 
 		bytes, err := os.ReadFile(activeProjectFilePath)
+		if os.IsNotExist(err) {
+			Projects = &UsersProjectsContext{}
+			return
+		}
 		common.CliExit(err)
 		activeProjects := UsersProjectsContext{}
 		_ = json.Unmarshal(bytes, &activeProjects)

--- a/test/test_util.go
+++ b/test/test_util.go
@@ -180,6 +180,7 @@ func loginInBrowser() error {
 	page := connection.MustPage("http://localhost:10000")
 
 	page.MustElement("#username").MustInput(testConfig().email)
+	page.MustElement("button[name=login]").MustClick()
 	page.MustElement("#password").MustInput(testConfig().password)
 	page.MustElement("button[name=login]").MustClick()
 	page.MustWaitLoad()


### PR DESCRIPTION
The issue was a regression introduced during the ZedToken change. GetZedToken was called before the first project resolution happened. Now it defaults to an empty projects state, so that the existing initialization is called, which creates an `active_projects.json` file and picks the first project returned as initial active project.